### PR TITLE
Copy blocks during `cholesky` factorization

### DIFF
--- a/benchmarks/cholesky_logging.jl
+++ b/benchmarks/cholesky_logging.jl
@@ -6,7 +6,7 @@ using Plots
 
 import TiledFactorization as TF
 
-capacity = 50
+capacity = 100
 sch = DataFlowTasks.JuliaScheduler(capacity)
 DataFlowTasks.setscheduler!(sch)
 
@@ -29,7 +29,7 @@ DataFlowTasks.resetlogger!()
 F = TF.cholesky!(B,tile_size)
 @info "Number of tasks = $(DataFlowTasks.TASKCOUNTER[])"
 @info "Number of threads = $(Threads.nthreads())"
-plot(logger;categories=["chol","ldiv","schur"])
+plot(logger;categories=["chol","ldiv","schur","copyin","copyout","Cholesky"])
 
 # using GraphViz: Graph
 # Graph(DataFlowTasks.logger_to_dot(logger))

--- a/benchmarks/cholesky_logging.jl
+++ b/benchmarks/cholesky_logging.jl
@@ -10,6 +10,8 @@ capacity = 100
 sch = DataFlowTasks.JuliaScheduler(capacity)
 DataFlowTasks.setscheduler!(sch)
 
+cp = Val(true)
+
 m         = 5_000
 tile_size = 256
 # create an SPD matrix
@@ -17,16 +19,18 @@ A = TF.spd_matrix(m)
 nt = Threads.nthreads()
 # go once to compile
 B = copy(A)
-F = TF.cholesky!(B,tile_size)
+F = TF.cholesky!(B,tile_size;copy=cp)
+@info "error: $(norm(F.L*F.U-A,Inf))"
 GC.gc()
-te = @elapsed TF.cholesky!(B,tile_size)
+te = @elapsed TF.cholesky!(B,tile_size;copy=cp)
 @info "elapsed: $te"
+
 GC.gc()
 # reset logger and run it again
 logger = DataFlowTasks.getlogger()
 DataFlowTasks.resetcounter!()
 DataFlowTasks.resetlogger!()
-F = TF.cholesky!(B,tile_size)
+F = TF.cholesky!(B,tile_size;copy=cp)
 @info "Number of tasks = $(DataFlowTasks.TASKCOUNTER[])"
 @info "Number of threads = $(Threads.nthreads())"
 plot(logger;categories=["chol","ldiv","schur","copyin","copyout","Cholesky"])

--- a/src/TiledFactorization.jl
+++ b/src/TiledFactorization.jl
@@ -18,15 +18,6 @@ using DataFlowTasks
 
 using DataFlowTasks: R,W,RW
 
-# FIXME: this probably belongs upstream at the DataFlowTasks package
-import DataFlowTasks: memory_overlap
-memory_overlap(L::UnitLowerTriangular,A) = memory_overlap(L.data,A)
-memory_overlap(A,L::UnitLowerTriangular) = memory_overlap(L,A)
-memory_overlap(U::UpperTriangular,A)     = memory_overlap(U.data,A)
-memory_overlap(U,L::UpperTriangular)     = memory_overlap(L,U)
-memory_overlap(U::Adjoint,A)             = memory_overlap(U.parent,A)
-memory_overlap(U,L::Adjoint)             = memory_overlap(L,U)
-
 function schur_complement!(C,A,B,threads::Val{T}=Val(false)) where {T}
     if T
         Octavian.matmul!(C,A,B,-1,1)

--- a/src/lu.jl
+++ b/src/lu.jl
@@ -42,8 +42,8 @@ function _lu!(A::PseudoTiledMatrix,tturbo::Val{T}=Val(false)) where {T}
         end
     end
     # wait for all computations before returning
-    DataFlowTasks.sync()
-    return LU(A.data,LinearAlgebra.BlasInt[],zero(LinearAlgebra.BlasInt))
+    res = @dspawn LU(@R(A.data),LinearAlgebra.BlasInt[],zero(LinearAlgebra.BlasInt)) label="LU"
+    return fetch(res)
 end
 
 # a fork-join approach for comparison with the data-flow parallelism

--- a/test/cholesky_test.jl
+++ b/test/cholesky_test.jl
@@ -5,8 +5,10 @@ using TiledFactorization
 A = TiledFactorization.spd_matrix(100)
 for tile_size in (10:15)
     for tturbo in (Val(false),Val(true))
-        F = TiledFactorization.cholesky(A,tile_size,tturbo)
-        @test F isa LinearAlgebra.Cholesky
-        @test F.L*F.U ≈ A
+        for copy in (Val(true),Val(false))
+            F = TiledFactorization.cholesky(A,tile_size,tturbo;copy)
+            @test F isa LinearAlgebra.Cholesky
+            @test F.L*F.U ≈ A
+        end
     end
 end


### PR DESCRIPTION
This branch implements [here](https://github.com/maltezfaria/TiledFactorization/blob/6967d393ff123582cbcfb5b41f0adc6912a4f372/src/cholesky.jl#L14-L71) a version of `chol` that copies the blocks into a contiguous for the factorization, then copies it back to the *standard* format. There does not seem to be an advantage in doing so, as the runtime is usually larger than the one obtained when `views` are used. Here is what a typical trace looks like (disregard the legends the `Activity` subplot, they are wrong):
![trace_copy_data](https://user-images.githubusercontent.com/6574742/176430092-3fb4cef2-9217-4086-b7d0-8139f5a31738.png)

Does it make sense to further pursue this approach? 

Edit: the figure was generated by running [this file](https://github.com/maltezfaria/TiledFactorization/blob/7ef6f4213f26ee240f28bf10ad6f99c73c00df35/benchmarks/cholesky_logging.jl)